### PR TITLE
feat: Align NodeRgbLibBinding with rgb-lib v5 and add address reuse support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,7 +30,9 @@ The primary wallet class is **`UTEXOWallet`**: initialize with a mnemonic (or se
 | `restoreUtxoWalletFromVss({ mnemonic, targetDir, config?, vssServerUrl? })` | Restore UTEXO wallet from VSS cloud backup – top-level function |
 | `deriveKeysFromMnemonic(network, mnemonic)` | Derive wallet keys from existing mnemonic |
 | `deriveKeysFromSeed(network, seed)` | Derive wallet keys from BIP39 seed |
-| `getAddress()` | Get deposit address (async) |
+| `getAddress()` | Get current deposit address (async) |
+| `rotateVanillaAddress()` | Rotate to the next vanilla (BTC) receive address and return it (async) |
+| `rotateColoredAddress()` | Rotate to the next colored (RGB) receive address and return it (async) |
 | `getBtcBalance()` | Get on-chain BTC balance (async) |
 | `getXpub()` | Get vanilla and colored xpubs |
 | `getNetwork()` | Get current network |
@@ -187,6 +189,11 @@ await wallet.initialize();
 const walletWithDir = new UTEXOWallet(keys.mnemonic, { network: 'testnet', dataDir: './wallet-data' });
 await walletWithDir.initialize();
 
+// Optional: enable address reuse — getAddress() returns the same address on every call
+// instead of advancing the derivation index. Default: false.
+const reuseWallet = new UTEXOWallet(keys.mnemonic, { network: 'testnet', reuseAddresses: true });
+await reuseWallet.initialize();
+
 // Restore from file backup (layer1 + utexo in one folder)
 const { targetDir } = restoreUtxoWalletFromBackup({
     backupPath: './backup-folder',
@@ -232,6 +239,20 @@ const asset = await wallet.issueAssetNia({
 });
 
 console.log('Asset issued:', asset.asset?.assetId);
+```
+
+### Address Reuse and Rotation
+
+By default, each call to `getAddress()` advances the derivation index so a fresh receive address is returned. Set `reuseAddresses: true` to keep returning the same address — useful for testing or scenarios where address rotation is handled externally.
+
+The address can be rotated manually at any time:
+
+```javascript
+// Advance to the next vanilla (BTC) receive address
+const newVanilla = await wallet.rotateVanillaAddress();
+
+// Advance to the next colored (RGB) receive address
+const newColored = await wallet.rotateColoredAddress();
 ```
 
 ### Asset Transfers

--- a/examples/create-utxos-asset.mjs
+++ b/examples/create-utxos-asset.mjs
@@ -12,7 +12,7 @@
 import { UTEXOWallet } from '../dist/index.mjs';
 
 const NETWORK = 'testnet';
-const MNEMONIC = "tobacco dinner advice together repeat digital need cancel lift near blind cute";
+const MNEMONIC = "slab deliver medal play immune enact drink inch okay pledge unknown stable";
 // drastic vacuum age family between general melody elbow ball very require pulp
 // const MNEMONIC = process.env.MNEMONIC || 'apple deposit job second wear metal zebra target filter chunk pill dynamic';
 // const MNEMONIC = process.env.MNEMONIC || 'famous hurt miss favorite pitch rich rude cricket fault hammer split guilt';
@@ -27,7 +27,7 @@ async function main() {
         const address = await wallet.getAddress();
         console.log('Wallet address:', address);
 
-        const count = await wallet.createUtxos({ num: 20, size: 1000 });
+        const count = await wallet.createUtxos({ num: 10, size: 1000 });
         await wallet.syncWallet();
         console.log('Created %d UTXO(s)', count);
 

--- a/examples/new-wallet.mjs
+++ b/examples/new-wallet.mjs
@@ -20,7 +20,7 @@ async function main() {
     
     console.log('Mnemonic:', keys.mnemonic);
 
-    const wallet = new UTEXOWallet(keys.mnemonic, { network: NETWORK });
+    const wallet = new UTEXOWallet(keys.mnemonic, { network: NETWORK, reuseAddresses: true });
     try {
         await wallet.initialize();
         const address = await wallet.getAddress();

--- a/examples/rotate-address.mjs
+++ b/examples/rotate-address.mjs
@@ -1,0 +1,77 @@
+/**
+ * Address rotation for the UTEXO RGB wallet (rgb-lib).
+ *
+ * - `reuseAddresses: false` — do not reuse the same receive addresses (rotation ON; SDK default).
+ *   Set `reuseAddresses: true` to reuse addresses (rotation OFF).
+ * - `rotateVanillaAddress()` / `rotateColoredAddress()` — manually advance vanilla or colored
+ *   receive derivation (see rgb-lib).
+ *
+ * Only the utexo wallet instance reads `reuseAddresses`; layer1 is unchanged.
+ *
+ *  node examples/rotate-address.mjs
+ *  MNEMONIC="..." ROTATION=true node examples/rotate-address.mjs
+ */
+
+import { UTEXOWallet } from '../dist/index.mjs';
+
+const NETWORK = process.env.NETWORK || 'testnet';
+const MNEMONIC =
+    process.env.MNEMONIC ||
+    'hybrid fame undo length tennis field cruel income media memory embrace reason';
+
+/** When true, pass `reuseAddresses: false` (derive new addresses instead of reusing). */
+const ROTATION =
+    process.env.ROTATION === undefined ? true : process.env.ROTATION === 'true';
+
+async function main() {
+    console.log('--- Rotate address (UTXO RGB wallet) ---');
+    console.log('Network:', NETWORK);
+    console.log('Address rotation ON (reuseAddresses: false):', ROTATION);
+
+    const wallet = new UTEXOWallet(MNEMONIC, {
+        network: NETWORK,
+        reuseAddresses: true,
+    });
+
+    try {
+        await wallet.initialize();
+
+        for (let i = 0; i < 5; i++) {
+        let addr0 = await wallet.getAddress();
+        console.log('getAddress (current):', addr0);
+        }
+
+        const vanilla = await wallet.rotateVanillaAddress();
+        console.log('rotateVanillaAddress →', vanilla);
+
+        const colored = await wallet.rotateColoredAddress();
+        console.log('rotateColoredAddress →', colored);
+
+        for (let i = 0; i < 5; i++) {
+            let addr0 = await wallet.getAddress();
+            console.log('getAddress (current):', addr0);
+            }
+    
+
+        try {
+            await wallet.syncWallet();
+            console.log('syncWallet: ok');
+            const balance = await wallet.getBtcBalance();
+            console.log('balance →',balance);
+        } catch (e) {
+            console.log('error →', JSON.stringify(e, null, 2));
+            console.log('syncWallet: skipped (indexer unavailable or invalid URL)');
+        }
+    } finally {
+        await wallet.dispose();
+    }
+
+    console.log('Done.');
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((err) => {
+        console.error('Error:', err);
+        process.exit(1);
+    });

--- a/examples/transfer.mjs
+++ b/examples/transfer.mjs
@@ -12,9 +12,9 @@
 import { UTEXOWallet } from '../dist/index.mjs';
 
 const NETWORK = 'testnet';
-const MNEMONIC_A = process.env.MNEMONIC_A || 'paddle smooth humble inherit reason basic brave clerk absorb later text that';
-const MNEMONIC_B = process.env.MNEMONIC_B || 'tobacco dinner advice together repeat digital need cancel lift near blind cute';
-const ASSET_ID = process.env.ASSET_ID||'rgb:4PhQDg98-kFPjSKO-HdbJOXo-IWt6P~a-HeVZA8L-A~tvBNU';
+const MNEMONIC_A = process.env.MNEMONIC_A || 'hybrid fame undo length tennis field cruel income media memory embrace reason';
+const MNEMONIC_B = process.env.MNEMONIC_B || 'slab deliver medal play immune enact drink inch okay pledge unknown stable';
+const ASSET_ID = process.env.ASSET_ID||'rgb:bOJpeaL1-4Og2TYO-z8hsInv-qTMH3Lj-AGuhVJ5-kAveVAM';
 if (!ASSET_ID) {
     console.error('ASSET_ID is required (e.g. from create-utxos-asset.mjs output)');
     process.exit(1);
@@ -42,7 +42,7 @@ async function main() {
         const amountBlind = 20;
 
         const invWitness = await walletB.witnessReceive({ amount: amountWitness });
-        console.log('Wallet B witness invoice created');
+        console.log('Wallet B witness invoice created',invWitness);
         const sendWitness = await walletA.send({
             invoice: invWitness.invoice,
             assetId: ASSET_ID,
@@ -52,7 +52,7 @@ async function main() {
         console.log('Witness transfer sent:', sendWitness);
 
         const invBlind = await walletB.blindReceive({ amount: amountBlind });
-        console.log('Wallet B blind invoice created');
+        console.log('Wallet B blind invoice created',invBlind);
         const sendBlind = await walletA.send({
             invoice: invBlind.invoice,
             assetId: ASSET_ID,
@@ -67,10 +67,10 @@ async function main() {
         await walletB.refreshWallet();
         await walletA.refreshWallet();
 
-        // const transfersA = await walletA.listTransfers(ASSET_ID); // sent stansfer should be settled
-        // const transfersB = await walletB.listTransfers(ASSET_ID); // received transfer should be settled
-        // console.log('Wallet A listTransfers:', transfersA.length, transfersA);
-        // console.log('allet B listTransfers:', transfersB.length, transfersB);
+        const transfersA = await walletA.listTransfers(ASSET_ID); // sent stansfer should be settled
+        const transfersB = await walletB.listTransfers(ASSET_ID); // received transfer should be settled
+        console.log('Wallet A listTransfers:', transfersA.length, transfersA);
+        console.log('allet B listTransfers:', transfersB.length, transfersB);
     } finally {
         await walletA.dispose();
         await walletB.dispose();

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "example:new-wallet": "node examples/new-wallet.mjs",
     "example:create-utxos-asset": "node examples/create-utxos-asset.mjs",
     "example:read-wallet": "node examples/read-wallet.mjs",
+    "example:rotate-address": "node examples/rotate-address.mjs",
     "example:transfer": "node examples/transfer.mjs",
     "example:onchain": "node examples/onchain-flow.mjs",
     "example:vss": "node examples/utexo-vss-backup-restore.mjs",
@@ -87,10 +88,10 @@
   "types": "./dist/index.d.ts",
   "dependencies": {
     "@bitcoindevkit/bdk-wallet-node": "^0.2.0",
-"@noble/hashes": "^2.0.1",
+    "@noble/hashes": "^2.0.1",
     "@scure/btc-signer": "^2.0.1",
-    "@utexo/rgb-lib": "0.3.0-beta.13",
-    "@utexo/rgb-sdk-core": "1.0.0-beta.2",
+    "@utexo/rgb-lib": "0.3.0-beta.16.dev",
+    "@utexo/rgb-sdk-core": "1.0.0-beta.3",
     "axios": "^1.8.4",
     "bare-node-runtime": "^1.1.4",
     "bitcoinjs-lib": "^6.1.7",
@@ -98,9 +99,9 @@
     "ripemd160": "^2.0.3"
   },
   "optionalDependencies": {
-    "@utexo/rgb-lib-darwin-arm64": "0.3.0-beta.13",
-    "@utexo/rgb-lib-linux-arm64": "0.3.0-beta.13",
-    "@utexo/rgb-lib-linux-x64": "0.3.0-beta.13"
+    "@utexo/rgb-lib-darwin-arm64": "0.3.0-beta.16.dev",
+    "@utexo/rgb-lib-linux-arm64": "0.3.0-beta.16.dev",
+    "@utexo/rgb-lib-linux-x64": "0.3.0-beta.16.dev"
   },
   "keywords": [
     "rgb",

--- a/src/binding/NodeRgbLibBinding.ts
+++ b/src/binding/NodeRgbLibBinding.ts
@@ -92,6 +92,32 @@ export const generateKeys = (
   return rgblib.generateKeys(mapNetworkToRgbLib(network));
 };
 
+export const validateConsignment = (params: {
+  filePath: string;
+  indexerUrl: string;
+  network: string;
+}): unknown => {
+  return (rgblib as any).validateConsignment(
+    params.filePath,
+    params.indexerUrl,
+    mapNetworkToRgbLib(params.network)
+  );
+};
+
+export const validateConsignmentOffchain = (params: {
+  filePath: string;
+  txid: string;
+  indexerUrl: string;
+  network: string;
+}): unknown => {
+  return (rgblib as any).validateConsignmentOffchain(
+    params.filePath,
+    params.txid,
+    params.indexerUrl,
+    mapNetworkToRgbLib(params.network)
+  );
+};
+
 export const restoreWallet = (params: {
   backupFilePath: string;
   password: string;
@@ -152,6 +178,18 @@ export const restoreFromVss = (params: {
 };
 
 /**
+ * Normalises the raw PSBT string returned by rgb-lib.
+ * Some calls return a plain base64 string; others wrap it as {"psbt":"<base64>"}.
+ */
+function extractPsbt(raw: string): string {
+  if (typeof raw === 'string' && raw.trimStart().startsWith('{')) {
+    const obj = JSON.parse(raw);
+    return obj?.psbt ?? raw;
+  }
+  return raw;
+}
+
+/**
  * RGB Lib Client class - Local implementation using rgb-lib
  */
 export class NodeRgbLibBinding implements IRgbLibBinding {
@@ -174,6 +212,9 @@ export class NodeRgbLibBinding implements IRgbLibBinding {
     network: string;
     transportEndpoint?: string;
     indexerUrl?: string;
+    reuseAddresses?: boolean;
+    vanillaKeychain?: number | null;
+    maxAllocationsPerUtxo?: number;
   }) {
     this.xpubVan = params.xpubVan;
     this.xpubCol = params.xpubCol;
@@ -198,15 +239,14 @@ export class NodeRgbLibBinding implements IRgbLibBinding {
       fs.mkdirSync(this.dataDir, { recursive: true });
     }
 
-    const walletData = {
+    const vanillaKeychain =
+      params.vanillaKeychain !== undefined ? params.vanillaKeychain : 0;
+    const walletData: Record<string, unknown> = {
       dataDir: this.dataDir,
       bitcoinNetwork: mapNetworkToRgbLib(this.originalNetwork),
       databaseType: rgblib.DatabaseType.Sqlite,
-      accountXpubVanilla: this.xpubVan,
-      accountXpubColored: this.xpubCol,
-      masterFingerprint: this.masterFingerprint,
-      maxAllocationsPerUtxo: '1',
-      vanillaKeychain: '0',
+      maxAllocationsPerUtxo: String(params.maxAllocationsPerUtxo ?? 1),
+      reuseAddresses: params.reuseAddresses ?? false,
       supportedSchemas: [
         rgblib.AssetSchema.Cfa,
         rgblib.AssetSchema.Nia,
@@ -214,8 +254,19 @@ export class NodeRgbLibBinding implements IRgbLibBinding {
       ],
     };
 
+    const singlesigKeys: Record<string, unknown> = {
+      accountXpubVanilla: this.xpubVan,
+      accountXpubColored: this.xpubCol,
+      masterFingerprint: this.masterFingerprint,
+      vanillaKeychain:
+        vanillaKeychain === null ? null : String(vanillaKeychain),
+    };
+
     try {
-      this.wallet = new rgblib.Wallet(new rgblib.WalletData(walletData));
+      this.wallet = new rgblib.Wallet(
+        new rgblib.WalletData(walletData),
+        new rgblib.SinglesigKeys(singlesigKeys)
+      );
     } catch (error) {
       throw new WalletError(
         'Failed to initialize rgb-lib wallet',
@@ -271,6 +322,14 @@ export class NodeRgbLibBinding implements IRgbLibBinding {
     return this.wallet.getAddress();
   }
 
+  async rotateVanillaAddress(): Promise<string> {
+    return this.wallet.rotateVanillaAddress();
+  }
+
+  async rotateColoredAddress(): Promise<string> {
+    return this.wallet.rotateColoredAddress();
+  }
+
   listUnspents(): Promise<Unspent[]> {
     const online = this.getOnline();
     const raw: RawUnspent[] = this.wallet.listUnspents(online, false, false);
@@ -313,7 +372,7 @@ export class NodeRgbLibBinding implements IRgbLibBinding {
     const feeRate = params.feeRate ? String(params.feeRate) : '1';
     const skipSync = false;
 
-    return this.wallet.createUtxosBegin(
+    const psbt = this.wallet.createUtxosBegin(
       online,
       upTo,
       num,
@@ -321,6 +380,8 @@ export class NodeRgbLibBinding implements IRgbLibBinding {
       feeRate,
       skipSync
     );
+
+    return extractPsbt(psbt);
   }
 
   async createUtxosEnd(params: CreateUtxosEndRequestModel): Promise<number> {
@@ -398,10 +459,12 @@ export class NodeRgbLibBinding implements IRgbLibBinding {
       recipientMap,
       donation,
       feeRate,
-      minConfirmations
+      minConfirmations,
+      null,
+      false
     );
 
-    return psbt;
+    return extractPsbt(psbt);
   }
 
   /**
@@ -447,10 +510,12 @@ export class NodeRgbLibBinding implements IRgbLibBinding {
       recipientMap,
       donation,
       feeRate,
-      minConfirmations
+      minConfirmations,
+      null,
+      false
     );
 
-    return psbt;
+    return extractPsbt(psbt);
   }
 
   async sendEnd(params: SendAssetEndRequestModel): Promise<SendResult> {
@@ -505,14 +570,17 @@ export class NodeRgbLibBinding implements IRgbLibBinding {
   async blindReceive(params: InvoiceRequest): Promise<InvoiceReceiveData> {
     const assetId = params.assetId || null;
     const assignment = `{"Fungible":${params.amount}}`;
-    const durationSeconds = String(params.durationSeconds ?? 2000);
+    const durationSeconds = params.durationSeconds ?? 2000;
+    const expirationTimestamp = String(
+      Math.floor(Date.now() / 1000) + durationSeconds
+    );
     const transportEndpoints: string[] = [this.transportEndpoint];
     const minConfirmations = String(params.minConfirmations ?? 3);
 
     const raw = this.wallet.blindReceive(
       assetId,
       assignment,
-      durationSeconds,
+      expirationTimestamp,
       transportEndpoints,
       minConfirmations
     );
@@ -527,14 +595,17 @@ export class NodeRgbLibBinding implements IRgbLibBinding {
   async witnessReceive(params: InvoiceRequest): Promise<InvoiceReceiveData> {
     const assetId = params.assetId || null;
     const assignment = `{"Fungible":${params.amount}}`;
-    const durationSeconds = String(params.durationSeconds ?? 2000);
+    const durationSeconds = params.durationSeconds ?? 2000;
+    const expirationTimestamp = String(
+      Math.floor(Date.now() / 1000) + durationSeconds
+    );
     const transportEndpoints: string[] = [this.transportEndpoint];
     const minConfirmations = String(params.minConfirmations ?? 3);
 
     const raw = this.wallet.witnessReceive(
       assetId,
       assignment,
-      durationSeconds,
+      expirationTimestamp,
       transportEndpoints,
       minConfirmations
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,12 @@ export type {
 // VSS backup exports (single-wallet restore; use restoreUtxoWalletFromVss for UTEXOWallet)
 export { restoreFromVss } from './binding/NodeRgbLibBinding';
 
+// Consignment validation
+export {
+  validateConsignment,
+  validateConsignmentOffchain,
+} from './binding/NodeRgbLibBinding';
+
 // Type exports
 export * from './types/rgb-model';
 export type {

--- a/src/utexo/utexo-wallet.ts
+++ b/src/utexo/utexo-wallet.ts
@@ -35,6 +35,7 @@ export class UTEXOWallet extends UTEXOWalletCore {
       dataDir: dataDir
         ? path.join(dataDir, String(this.networkMap.utexo), fp)
         : undefined,
+      reuseAddresses: this.options.reuseAddresses,
     });
 
     this.layer1Wallet = new WalletManager({

--- a/src/wallet/wallet-manager.ts
+++ b/src/wallet/wallet-manager.ts
@@ -66,6 +66,9 @@ export class WalletManager extends BaseWalletManager {
       transportEndpoint: params.transportEndpoint,
       indexerUrl: params.indexerUrl,
       dataDir,
+      reuseAddresses: params.reuseAddresses,
+      vanillaKeychain: params.vanillaKeychain,
+      maxAllocationsPerUtxo: params.maxAllocationsPerUtxo,
     });
 
     super(params, client, new NodeSigner());

--- a/tests/binding.test.ts
+++ b/tests/binding.test.ts
@@ -1,0 +1,456 @@
+/**
+ * Unit tests for NodeRgbLibBinding.
+ *
+ * Tests cover the three breaking changes introduced to align with the new
+ * rgb-lib wrapper.js:
+ *   1. Wallet constructor split — walletData + SinglesigKeys passed separately.
+ *   2. PSBT extraction — sendBegin/sendBeginBatch return {"psbt":"<base64>"},
+ *      createUtxosBegin returns a plain base64 string.
+ *   3. Expiration timestamp — blindReceive/witnessReceive convert durationSeconds
+ *      to an absolute unix timestamp before passing to rgb-lib.
+ */
+// @ts-nocheck - Jest mock types don't fully align with dynamic imports
+import { jest } from '@jest/globals';
+
+// ─── Shared mock wallet instance ──────────────────────────────────────────────
+
+const mockWallet = {
+  goOnline: jest.fn().mockReturnValue({ id: 'online' }),
+  getAddress: jest.fn().mockReturnValue('tb1ptest'),
+  rotateVanillaAddress: jest.fn().mockReturnValue('tb1pnew'),
+  rotateColoredAddress: jest.fn().mockReturnValue('tb1pnewcol'),
+  getBtcBalance: jest.fn().mockReturnValue({ vanilla: {}, colored: {} }),
+  listUnspents: jest.fn().mockReturnValue([]),
+  createUtxosBegin: jest.fn(),
+  createUtxosEnd: jest.fn().mockReturnValue(1),
+  sendBegin: jest.fn(),
+  sendEnd: jest.fn().mockReturnValue({ txid: 'abc', batchTransferIdx: 0 }),
+  blindReceive: jest.fn(),
+  witnessReceive: jest.fn(),
+  getAssetBalance: jest
+    .fn()
+    .mockReturnValue({ settled: 0, future: 0, spendable: 0 }),
+  listAssets: jest.fn().mockReturnValue({ nia: [], uda: [], cfa: [], ifa: [] }),
+  listTransactions: jest.fn().mockReturnValue([]),
+  listTransfers: jest.fn().mockReturnValue([]),
+  failTransfers: jest.fn().mockReturnValue(true),
+  deleteTransfers: jest.fn().mockReturnValue(true),
+  refresh: jest.fn(),
+  sync: jest.fn(),
+  backup: jest.fn(),
+  drop: jest.fn(),
+  issueAssetNIA: jest.fn(),
+};
+
+const MockWalletClass = jest.fn().mockImplementation(() => mockWallet);
+const MockWalletData = jest.fn().mockImplementation((d) => d);
+const MockSinglesigKeys = jest.fn().mockImplementation((k) => k);
+const MockInvoice = jest.fn().mockImplementation(() => ({
+  invoiceData: jest
+    .fn()
+    .mockReturnValue({ recipientId: 'r1', transportEndpoints: [] }),
+  drop: jest.fn(),
+}));
+
+await jest.unstable_mockModule('@utexo/rgb-lib', () => ({
+  default: {
+    DatabaseType: { Sqlite: 'Sqlite' },
+    AssetSchema: { Cfa: 'Cfa', Nia: 'Nia', Uda: 'Uda' },
+    BitcoinNetwork: {
+      Mainnet: 'Mainnet',
+      Testnet: 'Testnet',
+      Testnet4: 'Testnet4',
+      Signet: 'Signet',
+      Regtest: 'Regtest',
+    },
+    Wallet: MockWalletClass,
+    WalletData: MockWalletData,
+    SinglesigKeys: MockSinglesigKeys,
+    Invoice: MockInvoice,
+    dropOnline: jest.fn(),
+  },
+}));
+
+await jest.unstable_mockModule('fs', () => ({
+  default: {
+    existsSync: jest.fn().mockReturnValue(true),
+    mkdirSync: jest.fn(),
+  },
+  existsSync: jest.fn().mockReturnValue(true),
+  mkdirSync: jest.fn(),
+}));
+
+const { NodeRgbLibBinding } = await import('../src/binding/NodeRgbLibBinding');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const PLAIN_PSBT =
+  'cHNidP8BAP01AQIAAAABlMj9TfomLhMCT7H5tYcY0WkzknYqH+33Lr0ZlXUr+iEAAAAAAP3///8L6AMAAAAAAAAiUSA=';
+
+const WRAPPED_PSBT = JSON.stringify({ psbt: PLAIN_PSBT });
+
+const defaultParams = {
+  xpubVan: 'tpubVAN',
+  xpubCol: 'tpubCOL',
+  masterFingerprint: 'aabbccdd',
+  dataDir: '/tmp/test-wallet',
+  network: 'testnet',
+};
+
+function makeBinding(overrides: Partial<typeof defaultParams> = {}) {
+  return new NodeRgbLibBinding({ ...defaultParams, ...overrides });
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('NodeRgbLibBinding', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Re-apply defaults after clearAllMocks
+    mockWallet.goOnline.mockReturnValue({ id: 'online' });
+    MockWalletClass.mockImplementation(() => mockWallet);
+    MockWalletData.mockImplementation((d) => d);
+    MockSinglesigKeys.mockImplementation((k) => k);
+  });
+
+  // ─── 1. Constructor — walletData / SinglesigKeys split ──────────────────────
+
+  describe('constructor: WalletData and SinglesigKeys split', () => {
+    it('passes only data fields to WalletData (no xpubs or fingerprint)', () => {
+      makeBinding();
+
+      const walletDataArg = MockWalletData.mock.calls[0][0];
+      expect(walletDataArg).toHaveProperty('dataDir');
+      expect(walletDataArg).toHaveProperty('bitcoinNetwork');
+      expect(walletDataArg).toHaveProperty('databaseType');
+      expect(walletDataArg).toHaveProperty('maxAllocationsPerUtxo');
+      expect(walletDataArg).toHaveProperty('supportedSchemas');
+
+      // These must NOT appear in walletData anymore
+      expect(walletDataArg).not.toHaveProperty('accountXpubVanilla');
+      expect(walletDataArg).not.toHaveProperty('accountXpubColored');
+      expect(walletDataArg).not.toHaveProperty('masterFingerprint');
+      expect(walletDataArg).not.toHaveProperty('vanillaKeychain');
+    });
+
+    it('passes key fields to SinglesigKeys', () => {
+      makeBinding({ vanillaKeychain: 1 } as any);
+
+      const keysArg = MockSinglesigKeys.mock.calls[0][0];
+      expect(keysArg).toHaveProperty('accountXpubVanilla', 'tpubVAN');
+      expect(keysArg).toHaveProperty('accountXpubColored', 'tpubCOL');
+      expect(keysArg).toHaveProperty('masterFingerprint', 'aabbccdd');
+      expect(keysArg).toHaveProperty('vanillaKeychain', '1');
+    });
+
+    it('passes Wallet constructor both walletData and singlesigKeys', () => {
+      makeBinding();
+
+      expect(MockWalletClass).toHaveBeenCalledTimes(1);
+      expect(MockWalletClass.mock.calls[0]).toHaveLength(2);
+    });
+
+    it('defaults vanillaKeychain to "0" when not provided', () => {
+      makeBinding();
+
+      const keysArg = MockSinglesigKeys.mock.calls[0][0];
+      expect(keysArg.vanillaKeychain).toBe('0');
+    });
+
+    it('passes null for vanillaKeychain when explicitly set to null', () => {
+      makeBinding({ vanillaKeychain: null } as any);
+
+      const keysArg = MockSinglesigKeys.mock.calls[0][0];
+      expect(keysArg.vanillaKeychain).toBeNull();
+    });
+
+    it('includes reuseAddresses: true in walletData when set', () => {
+      makeBinding({ reuseAddresses: true } as any);
+
+      const walletDataArg = MockWalletData.mock.calls[0][0];
+      expect(walletDataArg.reuseAddresses).toBe(true);
+    });
+
+    it('defaults reuseAddresses to false in walletData', () => {
+      makeBinding();
+
+      const walletDataArg = MockWalletData.mock.calls[0][0];
+      expect(walletDataArg.reuseAddresses).toBe(false);
+    });
+  });
+
+  // ─── reuseAddresses: rotate address methods ──────────────────────────────────
+
+  describe('rotateVanillaAddress', () => {
+    it('delegates to wallet.rotateVanillaAddress and returns the new address', async () => {
+      mockWallet.rotateVanillaAddress.mockReturnValue('tb1pnewvanilla');
+
+      const binding = makeBinding();
+      const address = await binding.rotateVanillaAddress();
+
+      expect(mockWallet.rotateVanillaAddress).toHaveBeenCalledTimes(1);
+      expect(address).toBe('tb1pnewvanilla');
+    });
+
+    it('returns a different address each call (simulates rotation)', async () => {
+      mockWallet.rotateVanillaAddress
+        .mockReturnValueOnce('tb1pfirst')
+        .mockReturnValueOnce('tb1psecond');
+
+      const binding = makeBinding();
+      const first = await binding.rotateVanillaAddress();
+      const second = await binding.rotateVanillaAddress();
+
+      expect(first).toBe('tb1pfirst');
+      expect(second).toBe('tb1psecond');
+      expect(first).not.toBe(second);
+    });
+  });
+
+  describe('rotateColoredAddress', () => {
+    it('delegates to wallet.rotateColoredAddress and returns the new address', async () => {
+      mockWallet.rotateColoredAddress.mockReturnValue('tb1pnewcolored');
+
+      const binding = makeBinding();
+      const address = await binding.rotateColoredAddress();
+
+      expect(mockWallet.rotateColoredAddress).toHaveBeenCalledTimes(1);
+      expect(address).toBe('tb1pnewcolored');
+    });
+
+    it('does not call rotateVanillaAddress when rotating colored', async () => {
+      const binding = makeBinding();
+      await binding.rotateColoredAddress();
+
+      expect(mockWallet.rotateVanillaAddress).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── 2. PSBT extraction ────────────────────────────────────────────────────
+
+  describe('createUtxosBegin: handles plain base64 PSBT', () => {
+    it('returns the plain base64 string directly', async () => {
+      mockWallet.goOnline.mockReturnValue({ id: 'online' });
+      mockWallet.createUtxosBegin.mockReturnValue(PLAIN_PSBT);
+
+      const binding = makeBinding();
+      const result = await binding.createUtxosBegin({ feeRate: 2 });
+
+      expect(result).toBe(PLAIN_PSBT);
+    });
+
+    it('still extracts psbt from JSON-wrapped result if rgb-lib changes behaviour', async () => {
+      mockWallet.goOnline.mockReturnValue({ id: 'online' });
+      mockWallet.createUtxosBegin.mockReturnValue(WRAPPED_PSBT);
+
+      const binding = makeBinding();
+      const result = await binding.createUtxosBegin({ feeRate: 2 });
+
+      expect(result).toBe(PLAIN_PSBT);
+    });
+  });
+
+  describe('sendBegin: extracts psbt from JSON-wrapped result', () => {
+    beforeEach(() => {
+      mockWallet.goOnline.mockReturnValue({ id: 'online' });
+      MockInvoice.mockImplementation(() => ({
+        invoiceData: jest.fn().mockReturnValue({
+          recipientId: 'sb:wvout:abc',
+          transportEndpoints: ['rpcs://rgb-proxy.example.com/json-rpc'],
+        }),
+        drop: jest.fn(),
+      }));
+    });
+
+    it('returns the inner base64 psbt when rgb-lib wraps result in JSON', async () => {
+      mockWallet.sendBegin.mockReturnValue(WRAPPED_PSBT);
+
+      const binding = makeBinding();
+      const result = await binding.sendBegin({
+        invoice: 'rgb:~/~/abc',
+        assetId: 'rgb:asset1',
+        amount: 10,
+      });
+
+      expect(result).toBe(PLAIN_PSBT);
+    });
+
+    it('returns the plain base64 unchanged when rgb-lib returns it directly', async () => {
+      mockWallet.sendBegin.mockReturnValue(PLAIN_PSBT);
+
+      const binding = makeBinding();
+      const result = await binding.sendBegin({
+        invoice: 'rgb:~/~/abc',
+        assetId: 'rgb:asset1',
+        amount: 10,
+      });
+
+      expect(result).toBe(PLAIN_PSBT);
+    });
+
+    it('passes null and false as expirationTimestamp and dryRun', async () => {
+      mockWallet.sendBegin.mockReturnValue(PLAIN_PSBT);
+
+      const binding = makeBinding();
+      await binding.sendBegin({
+        invoice: 'rgb:~/~/abc',
+        assetId: 'rgb:asset1',
+        amount: 10,
+        feeRate: 3,
+        minConfirmations: 1,
+      });
+
+      const args = mockWallet.sendBegin.mock.calls[0];
+      // sendBegin(online, recipientMap, donation, feeRate, minConfirmations, expirationTimestamp, dryRun)
+      expect(args[5]).toBeNull(); // expirationTimestamp
+      expect(args[6]).toBe(false); // dryRun
+    });
+  });
+
+  describe('sendBeginBatch: extracts psbt from JSON-wrapped result', () => {
+    const recipientMap = {
+      'rgb:asset1': [
+        {
+          recipientId: 'sb:wvout:abc',
+          witnessData: null,
+          assignment: { Fungible: 10 },
+          transportEndpoints: ['rpcs://rgb-proxy.example.com/json-rpc'],
+        },
+      ],
+    };
+
+    it('returns the inner base64 psbt when rgb-lib wraps result in JSON', async () => {
+      mockWallet.goOnline.mockReturnValue({ id: 'online' });
+      mockWallet.sendBegin.mockReturnValue(WRAPPED_PSBT);
+
+      const binding = makeBinding();
+      const result = await binding.sendBeginBatch({ recipientMap });
+
+      expect(result).toBe(PLAIN_PSBT);
+    });
+
+    it('passes null and false as expirationTimestamp and dryRun', async () => {
+      mockWallet.goOnline.mockReturnValue({ id: 'online' });
+      mockWallet.sendBegin.mockReturnValue(PLAIN_PSBT);
+
+      const binding = makeBinding();
+      await binding.sendBeginBatch({ recipientMap, feeRate: 5 });
+
+      const args = mockWallet.sendBegin.mock.calls[0];
+      expect(args[5]).toBeNull();
+      expect(args[6]).toBe(false);
+    });
+  });
+
+  // ─── 3. Expiration timestamp in blindReceive / witnessReceive ───────────────
+
+  describe('blindReceive: passes absolute expiration timestamp', () => {
+    beforeEach(() => {
+      mockWallet.goOnline.mockReturnValue({ id: 'online' });
+      mockWallet.blindReceive.mockReturnValue({
+        invoice: 'rgb:~/~/inv',
+        recipientId: 'r1',
+        expirationTimestamp: 9999,
+        batchTransferIdx: 0,
+      });
+    });
+
+    it('converts durationSeconds to an absolute unix timestamp', async () => {
+      const before = Math.floor(Date.now() / 1000);
+
+      const binding = makeBinding();
+      await binding.blindReceive({ amount: 10, durationSeconds: 3600 });
+
+      const after = Math.floor(Date.now() / 1000);
+      const passedExpiry = Number(mockWallet.blindReceive.mock.calls[0][2]);
+
+      expect(passedExpiry).toBeGreaterThanOrEqual(before + 3600);
+      expect(passedExpiry).toBeLessThanOrEqual(after + 3600);
+    });
+
+    it('defaults durationSeconds to 2000 when not provided', async () => {
+      const before = Math.floor(Date.now() / 1000);
+
+      const binding = makeBinding();
+      await binding.blindReceive({ amount: 10 });
+
+      const after = Math.floor(Date.now() / 1000);
+      const passedExpiry = Number(mockWallet.blindReceive.mock.calls[0][2]);
+
+      expect(passedExpiry).toBeGreaterThanOrEqual(before + 2000);
+      expect(passedExpiry).toBeLessThanOrEqual(after + 2000);
+    });
+
+    it('passes expiration as a string (rgb-lib u64 convention)', async () => {
+      const binding = makeBinding();
+      await binding.blindReceive({ amount: 10, durationSeconds: 1000 });
+
+      const passedExpiry = mockWallet.blindReceive.mock.calls[0][2];
+      expect(typeof passedExpiry).toBe('string');
+    });
+
+    it('returns invoice data from the raw result', async () => {
+      const binding = makeBinding();
+      const result = await binding.blindReceive({ amount: 10 });
+
+      expect(result.invoice).toBe('rgb:~/~/inv');
+      expect(result.recipientId).toBe('r1');
+      expect(result.expirationTimestamp).toBe(9999);
+    });
+  });
+
+  describe('witnessReceive: passes absolute expiration timestamp', () => {
+    beforeEach(() => {
+      mockWallet.goOnline.mockReturnValue({ id: 'online' });
+      mockWallet.witnessReceive.mockReturnValue({
+        invoice: 'rgb:~/~/witness-inv',
+        recipientId: 'r2',
+        expirationTimestamp: 8888,
+        batchTransferIdx: 1,
+      });
+    });
+
+    it('converts durationSeconds to an absolute unix timestamp', async () => {
+      const before = Math.floor(Date.now() / 1000);
+
+      const binding = makeBinding();
+      await binding.witnessReceive({ amount: 5, durationSeconds: 7200 });
+
+      const after = Math.floor(Date.now() / 1000);
+      const passedExpiry = Number(mockWallet.witnessReceive.mock.calls[0][2]);
+
+      expect(passedExpiry).toBeGreaterThanOrEqual(before + 7200);
+      expect(passedExpiry).toBeLessThanOrEqual(after + 7200);
+    });
+
+    it('defaults durationSeconds to 2000 when not provided', async () => {
+      const before = Math.floor(Date.now() / 1000);
+
+      const binding = makeBinding();
+      await binding.witnessReceive({ amount: 5 });
+
+      const after = Math.floor(Date.now() / 1000);
+      const passedExpiry = Number(mockWallet.witnessReceive.mock.calls[0][2]);
+
+      expect(passedExpiry).toBeGreaterThanOrEqual(before + 2000);
+      expect(passedExpiry).toBeLessThanOrEqual(after + 2000);
+    });
+
+    it('passes expiration as a string (rgb-lib u64 convention)', async () => {
+      const binding = makeBinding();
+      await binding.witnessReceive({ amount: 5, durationSeconds: 1000 });
+
+      const passedExpiry = mockWallet.witnessReceive.mock.calls[0][2];
+      expect(typeof passedExpiry).toBe('string');
+    });
+
+    it('returns invoice data from the raw result', async () => {
+      const binding = makeBinding();
+      const result = await binding.witnessReceive({ amount: 5 });
+
+      expect(result.invoice).toBe('rgb:~/~/witness-inv');
+      expect(result.recipientId).toBe('r2');
+      expect(result.expirationTimestamp).toBe(8888);
+    });
+  });
+});

--- a/tests/utexo-wallet-mocked.test.ts
+++ b/tests/utexo-wallet-mocked.test.ts
@@ -62,6 +62,8 @@ const createMockWalletManager = () =>
     getAddress: jest
       .fn()
       .mockResolvedValue('tb1ptest1234567890abcdefghijklmnopqrstuvwxyz' as any),
+    rotateVanillaAddress: jest.fn().mockResolvedValue('tb1pnewvanilla'),
+    rotateColoredAddress: jest.fn().mockResolvedValue('tb1pnewcolored'),
     getBtcBalance: jest.fn().mockResolvedValue(mockBtcBalance),
     listUnspents: jest.fn().mockResolvedValue([]),
     listAssets: jest.fn().mockResolvedValue(mockListAssets),
@@ -129,10 +131,14 @@ const createMockWalletManager = () =>
     verifyMessage: jest.fn().mockResolvedValue(true),
   }) as any;
 
+const WalletManagerMock = jest
+  .fn()
+  .mockImplementation(() => createMockWalletManager());
+
 await jest.unstable_mockModule('../src/wallet/wallet-manager', () => {
   const mockInstance = createMockWalletManager();
   return {
-    WalletManager: jest.fn().mockImplementation(() => mockInstance),
+    WalletManager: WalletManagerMock,
     createWalletManager: jest.fn().mockImplementation(() => mockInstance),
     createWallet: jest.fn(),
     restoreFromBackup: jest.fn(),
@@ -235,6 +241,60 @@ describe('UTEXOWallet with mocked WalletManager', () => {
       amount: 10,
     });
     expect(result.invoice).toMatch(/^rgb:/);
+  });
+
+  it('should call rotateVanillaAddress and return result', async () => {
+    const result = await wallet.rotateVanillaAddress();
+    expect(result).toBeDefined();
+  });
+
+  it('should call rotateColoredAddress and return result', async () => {
+    const result = await wallet.rotateColoredAddress();
+    expect(result).toBeDefined();
+  });
+
+  describe('reuseAddresses propagation', () => {
+    it('passes reuseAddresses: true only to the utexo wallet, not layer1', async () => {
+      WalletManagerMock.mockClear();
+      const w = new UTEXOWallet(MNEMONIC, {
+        network: 'testnet',
+        reuseAddresses: true,
+      } as any);
+      await w.initialize();
+
+      // WalletManager is called twice: utexoWallet first, then layer1Wallet
+      expect(WalletManagerMock).toHaveBeenCalledTimes(2);
+      const [utexoCall, layer1Call] = WalletManagerMock.mock.calls;
+      expect(utexoCall[0].reuseAddresses).toBe(true);
+      expect(layer1Call[0].reuseAddresses).toBeUndefined();
+
+      await w.dispose();
+    });
+
+    it('passes reuseAddresses: false when option is false', async () => {
+      WalletManagerMock.mockClear();
+      const w = new UTEXOWallet(MNEMONIC, {
+        network: 'testnet',
+        reuseAddresses: false,
+      } as any);
+      await w.initialize();
+
+      const [utexoCall] = WalletManagerMock.mock.calls;
+      expect(utexoCall[0].reuseAddresses).toBe(false);
+
+      await w.dispose();
+    });
+
+    it('omits reuseAddresses when not provided in options', async () => {
+      WalletManagerMock.mockClear();
+      const w = new UTEXOWallet(MNEMONIC, { network: 'testnet' });
+      await w.initialize();
+
+      const [utexoCall] = WalletManagerMock.mock.calls;
+      expect(utexoCall[0].reuseAddresses).toBeUndefined();
+
+      await w.dispose();
+    });
   });
 
   describe('async methods return Promises', () => {


### PR DESCRIPTION
Changes

  rgb-lib binding alignment
  - Split Wallet constructor into separate WalletData and SinglesigKeys arguments to match the
   updated rgb-lib API
  - Add extractPsbt() helper to normalize PSBT output — sendBegin returns JSON-wrapped
  {"psbt":"..."} while createUtxosBegin returns raw base64; both are now handled transparently
  - Fix blindReceive/witnessReceive expiration: convert duration seconds to absolute unix
  timestamp before passing to rgb-lib
  - Export validateConsignment and validateConsignmentOffchain top-level functions

  Address reuse
  - Add reuseAddresses option to wallet config — when true, getAddress() returns the same
  address without advancing the derivation index                                         
  - Add rotateVanillaAddress() and rotateColoredAddress() methods for manual address rotation
  - reuseAddresses propagates only to the utexo wallet instance
                                                                                                                                     
  Docs                                                      
  - README: added reuseAddresses usage example and "Address Reuse and Rotation" section        